### PR TITLE
Add healthchecksdb to gitignore

### DIFF
--- a/content/.gitignore
+++ b/content/.gitignore
@@ -265,3 +265,6 @@ paket-files/
 # Python Tools for Visual Studio (PTVS)
 __pycache__/
 *.pyc
+
+# BeatPulse healthcheck temp database
+**/**/healthchecksdb


### PR DESCRIPTION
The healthchecksdb file is unimportant for the execution of the applications and it may cause conflicts when working in different branches. This PR adds it to the gitgnore file.