### PR TITLE
Replace Status Code cast for StatusCodes

### DIFF
--- a/content/Api/Blip.Api.Template/Middleware/ErrorHandlingMiddleware.cs
+++ b/content/Api/Blip.Api.Template/Middleware/ErrorHandlingMiddleware.cs
@@ -59,7 +59,7 @@ namespace Blip.Api.Template.Middleware
             else
             {
                 _logger.Error(exception, "[{@user}] Error: {@exception}", context.Request.Headers[Constants.BLIP_USER_HEADER], exception.Message);
-                context.Response.StatusCode = (int)HttpStatusCode.InternalServerError;
+                context.Response.StatusCode = StatusCodes.Status500InternalServerError;
             }
             
             string body = string.Empty;


### PR DESCRIPTION
The int cast for the HttpStatusCode is not necessary. It can be replaced by a StatusCodes.